### PR TITLE
Minor updates

### DIFF
--- a/ios/Plugin/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin/Plugin.swift
@@ -21,7 +21,9 @@ public class CapacitorDataStorageSqlite: CAPPlugin {
             call.reject("Must provide a value")
             return
         }
-        data.value = value
+        let cleanValue = value.replacingOccurrences(of: "\\", with: "\\");
+        
+        data.value = cleanValue
         let res: Bool = mDb.set(data:data)
 
         call.resolve([
@@ -41,9 +43,7 @@ public class CapacitorDataStorageSqlite: CAPPlugin {
             ])
 
         } else {
-            call.resolve([
-                "value": data.id!
-            ])
+            call.resolve(["result":false])
         }
     }
     


### PR DESCRIPTION
made updates to set to clean values from json also changed get to return false if there is no value in the db
```

        guard let value = call.options["value"] as? String else {
            call.reject("Must provide a value")
            return
        }
        let cleanValue = value.replacingOccurrences(of: "\\", with: "\\");
```

```
@objc func get(_ call: CAPPluginCall) {
        guard let key = call.options["key"] as? String else {
            call.reject("Must provide a key")
            return
        }
        let data: Data = mDb.get(name:key)!
        if data.id != nil {
            call.resolve([
                "value": data.value!
            ])

        } else {
            call.resolve(["result":false])
        }
    }
```