### PR TITLE
fix invalid error during update for existing key on iOS

### DIFF
--- a/ios/Plugin/Utils/UtilsSQLCipher.swift
+++ b/ios/Plugin/Utils/UtilsSQLCipher.swift
@@ -542,7 +542,7 @@ class UtilsSQLCipher {
                 .prepareSQL(mDB: mDB,
                             sql: updateStatementString,
                             values: values)
-            if lastId <= 0 {
+            if lastId < 0 {
                 let msg: String = "No data updated"
                 throw UtilsSQLCipherError.updateData(message: msg)
             }


### PR DESCRIPTION
The lastId returned by the prepareSQL statement equals zero in case of an update statement, caused by the sqlite3_last_insert_rowid call returning zero in case no data is inserted. Therefore lastId should be checked against < 0 instead of <= 0 to prevent errors during the update of existing keys.