### PR TITLE
fix: migrate Android SQLCipher for 16KB page support

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation "androidx.coordinatorlayout:coordinatorlayout:1.3.0"
-    implementation 'net.zetetic:android-database-sqlcipher:4.4.3@aar'
+    implementation 'net.zetetic:sqlcipher-android:4.16.0@aar'
     implementation "androidx.sqlite:sqlite:2.6.2"
 
 }

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
@@ -1,6 +1,7 @@
 package com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils;
 
 import android.content.Context;
+import android.database.Cursor;
 import android.util.Log;
 import androidx.sqlite.db.SimpleSQLiteQuery;
 import androidx.sqlite.db.SupportSQLiteDatabase;
@@ -10,11 +11,11 @@ import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.Impor
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.ImportExportJson.JsonTable;
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.ImportExportJson.JsonValue;
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import net.sqlcipher.Cursor;
-import net.sqlcipher.database.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
 
 public class StorageDatabaseHelper {
 
@@ -63,7 +64,7 @@ public class StorageDatabaseHelper {
      */
     private void InitializeSQLCipher() {
         Log.d(TAG, " in InitializeSQLCipher: ");
-        SQLiteDatabase.loadLibs(_context);
+        System.loadLibrary("sqlcipher");
     }
 
     /**
@@ -95,7 +96,7 @@ public class StorageDatabaseHelper {
         }
         if (_mode.equals("encryption")) {
             try {
-                _uCipher.encrypt(_context, _file, SQLiteDatabase.getBytes(password.toCharArray()));
+                _uCipher.encrypt(_context, _file, password.getBytes(StandardCharsets.UTF_8));
             } catch (Exception e) {
                 String msg = "Failed in encryption " + e.getMessage();
                 Log.v(TAG, msg);
@@ -103,7 +104,7 @@ public class StorageDatabaseHelper {
             }
         }
 
-        _db = SQLiteDatabase.openOrCreateDatabase(_file, password, null);
+        _db = SQLiteDatabase.openOrCreateDatabase(_file, password, null, null, null);
         if (_db != null) {
             if (_db.isOpen()) {
                 try {

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/UtilsSQLCipher.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/UtilsSQLCipher.java
@@ -1,12 +1,12 @@
 package com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils;
 
 import android.content.Context;
+import android.database.sqlite.SQLiteException;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import net.sqlcipher.database.SQLiteDatabase;
-import net.sqlcipher.database.SQLiteException;
-import net.sqlcipher.database.SQLiteStatement;
+import net.zetetic.database.sqlcipher.SQLiteDatabase;
+import net.zetetic.database.sqlcipher.SQLiteStatement;
 
 public class UtilsSQLCipher {
 
@@ -37,14 +37,14 @@ public class UtilsSQLCipher {
             SQLiteDatabase db = null;
 
             try {
-                db = SQLiteDatabase.openDatabase(dbPath.getAbsolutePath(), "", null, SQLiteDatabase.OPEN_READONLY);
+                db = SQLiteDatabase.openDatabase(dbPath.getAbsolutePath(), "", null, SQLiteDatabase.OPEN_READONLY, null);
 
                 db.getVersion();
 
                 return (State.UNENCRYPTED);
             } catch (Exception e) {
                 try {
-                    db = SQLiteDatabase.openDatabase(dbPath.getAbsolutePath(), globVar.secret, null, SQLiteDatabase.OPEN_READONLY);
+                    db = SQLiteDatabase.openDatabase(dbPath.getAbsolutePath(), globVar.secret, null, SQLiteDatabase.OPEN_READONLY, null);
                     return (State.ENCRYPTED_SECRET);
                 } catch (Exception e1) {
                     return (State.ENCRYPTED_NEW_SECRET);
@@ -72,11 +72,11 @@ public class UtilsSQLCipher {
      * @throws IOException
      */
     public void encrypt(Context ctxt, File originalFile, byte[] passphrase) throws IOException {
-        SQLiteDatabase.loadLibs(ctxt);
+        System.loadLibrary("sqlcipher");
 
         if (originalFile.exists()) {
             File newFile = File.createTempFile("sqlcipherutils", "tmp", ctxt.getCacheDir());
-            SQLiteDatabase db = SQLiteDatabase.openDatabase(originalFile.getAbsolutePath(), "", null, SQLiteDatabase.OPEN_READWRITE);
+            SQLiteDatabase db = SQLiteDatabase.openDatabase(originalFile.getAbsolutePath(), "", null, SQLiteDatabase.OPEN_READWRITE, null);
             int version = db.getVersion();
 
             db.close();
@@ -104,10 +104,10 @@ public class UtilsSQLCipher {
     }
 
     public void changePassword(Context ctxt, File file, String password, String nwpassword) throws IOException {
-        SQLiteDatabase.loadLibs(ctxt);
+        System.loadLibrary("sqlcipher");
 
         if (file.exists()) {
-            SQLiteDatabase db = SQLiteDatabase.openDatabase(file.getAbsolutePath(), password, null, SQLiteDatabase.OPEN_READWRITE);
+            SQLiteDatabase db = SQLiteDatabase.openDatabase(file.getAbsolutePath(), password, null, SQLiteDatabase.OPEN_READWRITE, null);
 
             if (!db.isOpen()) {
                 throw new SQLiteException("database " + file.getAbsolutePath() + " open failed");


### PR DESCRIPTION
## Summary
- replace deprecated Android SQLCipher artifact with net.zetetic:sqlcipher-android 4.16.0
- update Android imports and database open calls for the new net.zetetic.database.sqlcipher API
- load the native sqlcipher library with System.loadLibrary as required by the replacement library

Fixes #187.

## Validation
- bun run build
- bun run eslint (passes with existing warnings in electron/src/index.ts)
- bun run prettier -- --check
- bun run swiftlint -- lint (passes with existing warnings)
- JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ANDROID_SDK_ROOT=/Users/martindonadieu/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home/bin:/Users/martindonadieu/Library/Android/sdk/platform-tools:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Users/martindonadieu/.vite-plus/bin:/Users/martindonadieu/.bun/bin:/Users/martindonadieu/.cargo/bin:/Users/martindonadieu/.orbstack/bin bun run verify:android