### PR TITLE
[codex] fix encrypted openStore for fresh databases

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
@@ -93,7 +93,7 @@ public class StorageDatabaseHelper {
                 throw new Exception(msg);
             }
         }
-        if (_mode.equals("encryption")) {
+        if (_mode.equals("encryption") && _file.exists()) {
             try {
                 _uCipher.encrypt(_context, _file, SQLiteDatabase.getBytes(password.toCharArray()));
             } catch (Exception e) {

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/StorageDatabaseHelper.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/StorageDatabaseHelper.swift
@@ -106,7 +106,7 @@ class StorageDatabaseHelper {
 
             }
         }
-        if mode == "encryption" {
+        if mode == "encryption" && UtilsFile.isFileExist(filePath: path) {
             do {
                 let ret: Bool = try UtilsEncryption
                     .encryptDatabase(filePath: path, password: password)

--- a/ios/Tests/CapgoCapacitorDataStorageSqlitePluginTests/CapacitorDataStorageSqlitePluginTests.swift
+++ b/ios/Tests/CapgoCapacitorDataStorageSqlitePluginTests/CapacitorDataStorageSqlitePluginTests.swift
@@ -2,12 +2,62 @@ import XCTest
 @testable import CapgoCapacitorDataStorageSqlitePlugin
 
 final class CapgoCapacitorDataStorageSqliteTests: XCTestCase {
-    func testEcho() {
-        // Ensure the basic iOS helper reflects the provided value.
+    func testOpenStoreCreatesFreshStore() throws {
+        let storeName = uniqueStoreName(prefix: "plain")
+        let fileName = "\(storeName)SQLite.db"
         let implementation = CapgoCapacitorDataStorageSqlite()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
 
-        XCTAssertEqual(value, result)
+        try? UtilsFile.deleteFile(fileName: fileName)
+        defer {
+            try? implementation.closeStore(storeName)
+            try? UtilsFile.deleteFile(fileName: fileName)
+        }
+
+        XCTAssertNoThrow(
+            try implementation.openStore(
+                storeName,
+                tableName: "saveData",
+                encrypted: false,
+                inMode: "no-encryption"
+            )
+        )
+
+        let exists = try implementation.isStoreExists(storeName)
+        XCTAssertEqual(exists.intValue, 1)
+    }
+
+    func testOpenStoreCreatesFreshEncryptedStore() throws {
+        let storeName = uniqueStoreName(prefix: "issue58")
+        let fileName = "\(storeName)SQLite.db"
+        let implementation = CapgoCapacitorDataStorageSqlite()
+
+        try? UtilsFile.deleteFile(fileName: fileName)
+        defer {
+            try? implementation.closeStore(storeName)
+            try? UtilsFile.deleteFile(fileName: fileName)
+        }
+
+        XCTAssertNoThrow(
+            try implementation.openStore(
+                storeName,
+                tableName: "saveData",
+                encrypted: true,
+                inMode: "encryption"
+            )
+        )
+        XCTAssertNoThrow(try implementation.closeStore(storeName))
+        XCTAssertNoThrow(
+            try implementation.openStore(
+                storeName,
+                tableName: "saveData",
+                encrypted: true,
+                inMode: "secret"
+            )
+        )
+    }
+
+    private func uniqueStoreName(prefix: String) -> String {
+        let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        return "\(prefix)_\(suffix)"
     }
 }


### PR DESCRIPTION
## What
- Allow encrypted `openStore` with `mode: "encryption"` to create a fresh database instead of failing when no database file exists yet.
- Apply the same guard on iOS and Android.
- Replace the stale iOS `echo` test with real open-store coverage and add a regression test for issue 58.

## Why
- Fixes #58.
- The previous native code always tried to convert an existing plaintext database for `mode: "encryption"`; on a fresh install there is no file yet, so iOS returned `openStore: Failed in encryption`.

## How
- Only run the plaintext-to-encrypted conversion when the database file already exists.
- Let the existing SQLCipher open/create path create a fresh encrypted database with the configured secret.

## Testing
- `bun install`
- `bun run eslint` (passes with 2 existing warnings)
- `bun run prettier -- --check`
- `bun run swiftlint -- lint` (passes with 3 existing warnings)
- `bun run check:wiring`
- Manual web build path: `bun run clean`, `bun run docgen`, `bunx tsc`, `bunx rollup -c rollup.config.mjs`
- `bun run verify:ios`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk ./gradlew clean build test`
- `xcodebuild test -scheme CapgoCapacitorDataStorageSqlite -destination 'id=94B6CA17-4FF7-4B8C-871C-E08AA21BCE6A'`

## Not Tested
- Manual verification inside a separate consuming Capacitor app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Database encryption logic is now only triggered when encryption mode is enabled and the database file already exists, preventing unnecessary operations during new database creation.

* **Tests**
  * Added iOS tests to verify store creation and encryption functionality.

* **Chores**
  * Improved platform setup script to conditionally install Capacitor platforms only when needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Cap-go/capacitor-data-storage-sqlite/pull/198?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->