### PR TITLE
[codex] add SQLite vacuum controls

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -40,13 +40,17 @@ bun run build
 
 case "$platform" in
   android)
-    bunx cap add android
+    if [ ! -d android ]; then
+      bunx cap add android
+    fi
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    if [ ! -d ios ]; then
+      bunx cap add ios
+    fi
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/README.md
+++ b/README.md
@@ -237,8 +237,10 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 * [`importFromJson(...)`](#importfromjson)
 * [`isJsonValid(...)`](#isjsonvalid)
 * [`exportToJson()`](#exporttojson)
+* [`vacuum()`](#vacuum)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
+* [Type Aliases](#type-aliases)
 
 </docgen-index>
 
@@ -604,6 +606,19 @@ Export the given database to a JSON Object
 --------------------
 
 
+### vacuum()
+
+```typescript
+vacuum() => Promise<void>
+```
+
+Rebuild the current SQLite store to reclaim unused disk space.
+
+**Since:** 8.0.32
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -622,12 +637,13 @@ Get the native Capacitor plugin version
 
 #### capOpenStorageOptions
 
-| Prop            | Type                 | Description                                                                 |
-| --------------- | -------------------- | --------------------------------------------------------------------------- |
-| **`database`**  | <code>string</code>  | The storage database name                                                   |
-| **`table`**     | <code>string</code>  | The storage table name                                                      |
-| **`encrypted`** | <code>boolean</code> | Set to true for database encryption                                         |
-| **`mode`**      | <code>string</code>  | * Set the mode for database encryption ["encryption", "secret","newsecret"] |
+| Prop             | Type                                                                | Description                                                                                                                                                |
+| ---------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`database`**   | <code>string</code>                                                 | The storage database name                                                                                                                                  |
+| **`table`**      | <code>string</code>                                                 | The storage table name                                                                                                                                     |
+| **`encrypted`**  | <code>boolean</code>                                                | Set to true for database encryption                                                                                                                        |
+| **`mode`**       | <code>string</code>                                                 | * Set the mode for database encryption ["encryption", "secret","newsecret"]                                                                                |
+| **`autoVacuum`** | <code><a href="#capsqliteautovacuum">capSQLiteAutoVacuum</a></code> | Set the SQLite auto_vacuum mode for the store. Use `none`/`0`, `full`/`1`, or `incremental`/`2`. iOS, Android, and Electron only. Web ignores this option. |
 
 
 #### capStorageOptions
@@ -738,6 +754,14 @@ Get the native Capacitor plugin version
 | ------------ | ------------------------------------ | ------------------------------------------------------------------------------ |
 | **`name`**   | <code>string</code>                  | The database name                                                              |
 | **`values`** | <code>capDataStorageOptions[]</code> | * Array of Values (<a href="#capdatastorageoptions">capDataStorageOptions</a>) |
+
+
+### Type Aliases
+
+
+#### capSQLiteAutoVacuum
+
+<code>'none' | 'full' | 'incremental' | 0 | 1 | 2</code>
 
 </docgen-api>
 

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
@@ -19,9 +19,10 @@ public class CapgoCapacitorDataStorageSqlite {
         this.context = context;
     }
 
-    public void openStore(String dbName, String tableName, Boolean encrypted, String inMode, int version) throws Exception {
+    public void openStore(String dbName, String tableName, Boolean encrypted, String inMode, int version, String autoVacuum)
+        throws Exception {
         try {
-            mDb = new StorageDatabaseHelper(context, dbName + "SQLite.db", tableName, encrypted, inMode, version);
+            mDb = new StorageDatabaseHelper(context, dbName + "SQLite.db", tableName, encrypted, inMode, version, autoVacuum);
             if (mDb != null) {
                 mDb.open();
                 if (mDb.isOpen) {
@@ -250,6 +251,19 @@ public class CapgoCapacitorDataStorageSqlite {
         }
     }
 
+    public void vacuum() throws Exception {
+        if (mDb != null && mDb.isOpen) {
+            try {
+                mDb.vacuum();
+                return;
+            } catch (Exception e) {
+                throw new Exception(e.getMessage());
+            }
+        } else {
+            throw new Exception("mDb is not opened or null");
+        }
+    }
+
     public void deleteStore(String dbName) throws Exception {
         try {
             context.deleteDatabase(dbName + "SQLite.db");
@@ -307,7 +321,7 @@ public class CapgoCapacitorDataStorageSqlite {
             ArrayList<JsonTable> tables = jsonSQL.getTables();
             for (JsonTable table : tables) {
                 // open the database
-                mDb = new StorageDatabaseHelper(context, dbName + "SQLite.db", table.getName(), encrypted, inMode, 1);
+                mDb = new StorageDatabaseHelper(context, dbName + "SQLite.db", table.getName(), encrypted, inMode, 1, null);
                 if (mDb != null) {
                     mDb.open();
                     if (mDb.isOpen) {

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java
@@ -34,6 +34,8 @@ public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin {
         String secret = null;
         String newsecret = null;
         String inMode = null;
+        Object autoVacuumValue = call.getData().opt("autoVacuum");
+        String autoVacuum = autoVacuumValue != null ? autoVacuumValue.toString() : null;
 
         if (encrypted) {
             inMode = call.getString("mode", "no-encryption");
@@ -52,7 +54,7 @@ public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin {
             inMode = "no-encryption";
         }
         try {
-            implementation.openStore(dbName, tableName, encrypted, inMode, 1);
+            implementation.openStore(dbName, tableName, encrypted, inMode, 1, autoVacuum);
             rHandler.retResult(call, null, null);
             return;
         } catch (Exception e) {
@@ -428,6 +430,19 @@ public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin {
         } catch (Exception e) {
             String msg = "ExportToJson: " + e.getMessage();
             rHandler.retJsonObject(call, retObj, msg);
+            return;
+        }
+    }
+
+    @PluginMethod
+    public void vacuum(PluginCall call) {
+        try {
+            implementation.vacuum();
+            rHandler.retResult(call, null, null);
+            return;
+        } catch (Exception e) {
+            String msg = "Vacuum: " + e.getMessage();
+            rHandler.retResult(call, null, msg);
             return;
         }
     }

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
@@ -27,6 +27,7 @@ public class StorageDatabaseHelper {
     private String _mode;
     private String _secret;
     private String _newsecret;
+    private String _autoVacuum;
     private int _dbVersion;
     private File _file;
     private Global _globVar;
@@ -39,13 +40,22 @@ public class StorageDatabaseHelper {
     private static final String COL_VALUE = "value";
     private static final String IDX_COL_NAME = "name";
 
-    public StorageDatabaseHelper(Context context, String dbName, String tableName, Boolean encrypted, String mode, int vNumber) {
+    public StorageDatabaseHelper(
+        Context context,
+        String dbName,
+        String tableName,
+        Boolean encrypted,
+        String mode,
+        int vNumber,
+        String autoVacuum
+    ) {
         this._context = context;
         this._dbName = dbName;
         this._tableName = tableName;
         this._dbVersion = vNumber;
         this._encrypted = encrypted;
         this._mode = mode;
+        this._autoVacuum = autoVacuum;
         this._file = context.getDatabasePath(dbName);
         this._globVar = new Global();
         this._uCipher = new UtilsSQLCipher();
@@ -107,6 +117,7 @@ public class StorageDatabaseHelper {
         if (_db != null) {
             if (_db.isOpen()) {
                 try {
+                    configureAutoVacuum();
                     setTable(_tableName, true);
                     isOpen = true;
                     return;
@@ -123,6 +134,51 @@ public class StorageDatabaseHelper {
         } else {
             isOpen = false;
             throw new Exception("No store returned");
+        }
+    }
+
+    private int normalizeAutoVacuum(String autoVacuum) throws Exception {
+        if (autoVacuum == null || autoVacuum.trim().isEmpty()) {
+            return -1;
+        }
+        String value = autoVacuum.trim().toLowerCase();
+        if (value.equals("0") || value.equals("none")) {
+            return 0;
+        }
+        if (value.equals("1") || value.equals("full")) {
+            return 1;
+        }
+        if (value.equals("2") || value.equals("incremental")) {
+            return 2;
+        }
+        throw new Exception("autoVacuum must be one of none, full, incremental, 0, 1, or 2");
+    }
+
+    private int getAutoVacuumMode() throws Exception {
+        Cursor c = null;
+        try {
+            c = (Cursor) _db.query("PRAGMA auto_vacuum;");
+            if (c.moveToFirst()) {
+                return c.getInt(0);
+            }
+            return 0;
+        } catch (Exception e) {
+            String msg = "Failed in getAutoVacuumMode " + e.getMessage();
+            throw new Exception(msg);
+        } finally {
+            if (c != null) c.close();
+        }
+    }
+
+    private void configureAutoVacuum() throws Exception {
+        int mode = normalizeAutoVacuum(_autoVacuum);
+        if (mode < 0) {
+            return;
+        }
+        int currentMode = getAutoVacuumMode();
+        if (currentMode != mode) {
+            _db.execSQL("PRAGMA auto_vacuum = " + mode + ";");
+            _db.execSQL("VACUUM;");
         }
     }
 
@@ -518,6 +574,20 @@ public class StorageDatabaseHelper {
                 }
             } catch (Exception e) {
                 String msg = "Failed in deleteTable" + e.getMessage();
+                throw new Exception(msg);
+            }
+        } else {
+            throw new Exception("Store not opened");
+        }
+    }
+
+    public void vacuum() throws Exception {
+        if (_db.isOpen()) {
+            try {
+                _db.execSQL("VACUUM;");
+                return;
+            } catch (Exception e) {
+                String msg = "Failed in vacuum" + e.getMessage();
                 throw new Exception(msg);
             }
         } else {

--- a/electron/src/electron-utils/StorageDatabaseHelper.ts
+++ b/electron/src/electron-utils/StorageDatabaseHelper.ts
@@ -1,4 +1,4 @@
-import type { capDataStorageOptions, JsonStore, JsonTable } from '../../../src/definitions';
+import type { capDataStorageOptions, capSQLiteAutoVacuum, JsonStore, JsonTable } from '../../../src/definitions';
 
 import { Data } from './Data';
 import { UtilsSQLite } from './UtilsSQLite';
@@ -23,7 +23,7 @@ export class StorageDatabaseHelper {
     this._utils = new UtilsSQLite();
   }
 
-  public async openStore(dbName: string, tableName: string): Promise<void> {
+  public async openStore(dbName: string, tableName: string, autoVacuum?: capSQLiteAutoVacuum): Promise<void> {
     try {
       this.db = await this._utils.connection(
         dbName,
@@ -31,6 +31,7 @@ export class StorageDatabaseHelper {
         /*,this._secret*/
       );
       if (this.db !== null) {
+        await this._configureAutoVacuum(autoVacuum);
         await this._createTable(tableName);
         this.dbName = dbName;
         this.tableName = tableName;
@@ -48,6 +49,64 @@ export class StorageDatabaseHelper {
       this.isOpen = false;
       return Promise.reject(err);
     }
+  }
+  private _normalizeAutoVacuum(autoVacuum?: capSQLiteAutoVacuum): number | null {
+    if (autoVacuum == null) {
+      return null;
+    }
+    const value = `${autoVacuum}`.trim().toLowerCase();
+    if (value === '0' || value === 'none') {
+      return 0;
+    }
+    if (value === '1' || value === 'full') {
+      return 1;
+    }
+    if (value === '2' || value === 'incremental') {
+      return 2;
+    }
+    throw new Error('autoVacuum must be one of none, full, incremental, 0, 1, or 2');
+  }
+  private async _execSQL(sql: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (this.db == null) {
+        reject(`this.db is null in execSQL`);
+        return;
+      }
+      this.db.exec(sql, (err: Error) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+  private async _getAutoVacuumMode(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      if (this.db == null) {
+        reject(`this.db is null in getAutoVacuumMode`);
+        return;
+      }
+      this.db.get('PRAGMA auto_vacuum;', (err: Error, row: Record<string, number>) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(Number(Object.values(row ?? {})[0] ?? 0));
+        }
+      });
+    });
+  }
+  private async _configureAutoVacuum(autoVacuum?: capSQLiteAutoVacuum): Promise<void> {
+    const mode = this._normalizeAutoVacuum(autoVacuum);
+    if (mode == null) {
+      return Promise.resolve();
+    }
+    const currentMode = await this._getAutoVacuumMode();
+    if (currentMode !== mode) {
+      await this._execSQL(`PRAGMA auto_vacuum = ${mode};`);
+      await this._execSQL('VACUUM;');
+    }
+    return Promise.resolve();
   }
   public async closeStore(dbName: string): Promise<void> {
     if (dbName === this.dbName && this.isOpen && this.db != null) {
@@ -456,6 +515,17 @@ export class StorageDatabaseHelper {
       } else {
         return Promise.resolve();
       }
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+  public async vacuum(): Promise<void> {
+    if (this.db == null) {
+      return Promise.reject(`this.db is null in vacuum`);
+    }
+    try {
+      await this._execSQL('VACUUM;');
+      return Promise.resolve();
     } catch (err) {
       return Promise.reject(err);
     }

--- a/electron/src/index.ts
+++ b/electron/src/index.ts
@@ -1,7 +1,5 @@
 import type {
   CapgoCapacitorDataStorageSqlitePlugin,
-  capEchoOptions,
-  capEchoResult,
   capDataStorageOptions,
   capDataStorageResult,
   capFilterStorageOptions,
@@ -17,6 +15,7 @@ import type {
   capStoreJson,
   capDataStorageChanges,
   capStoreImportOptions,
+  capSQLiteAutoVacuum,
 } from '../../src/definitions';
 
 import { Data } from './electron-utils/Data';
@@ -31,8 +30,9 @@ export class CapgoCapacitorDataStorageSqlite implements CapgoCapacitorDataStorag
   async openStore(options: capOpenStorageOptions): Promise<void> {
     const dbName = options.database ? `${options.database}SQLite.db` : 'storageSQLite.db';
     const tableName = options.table ? options.table : 'storage_store';
+    const autoVacuum: capSQLiteAutoVacuum | undefined = options.autoVacuum;
     try {
-      await this.mDb.openStore(dbName, tableName);
+      await this.mDb.openStore(dbName, tableName, autoVacuum);
       return Promise.resolve();
     } catch (err) {
       return Promise.reject(err);
@@ -294,6 +294,15 @@ export class CapgoCapacitorDataStorageSqlite implements CapgoCapacitorDataStorag
       return Promise.resolve({ export: ret });
     } catch (err) {
       return Promise.reject(`exportToJson: ${err.message}`);
+    }
+  }
+
+  async vacuum(): Promise<void> {
+    try {
+      await this.mDb.vacuum();
+      return Promise.resolve();
+    } catch (err) {
+      return Promise.reject(`vacuum: ${err.message}`);
     }
   }
 }

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
@@ -12,14 +12,19 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
     // MARK: - OpenStore
 
     @objc func openStore(_ dbName: String, tableName: String,
-                         encrypted: Bool, inMode: String
+                         encrypted: Bool, inMode: String,
+                         autoVacuum: String?
     ) throws {
         do {
             mDb = try StorageDatabaseHelper(
                 databaseName: "\(dbName)SQLite.db",
                 tableName: tableName,
-                encrypted: encrypted, mode: inMode)
+                encrypted: encrypted, mode: inMode,
+                autoVacuum: autoVacuum)
         } catch StorageHelperError.initFailed(let message) {
+            throw CapgoCapacitorDataStorageSqliteError
+            .failed(message: message)
+        } catch StorageHelperError.autoVacuum(let message) {
             throw CapgoCapacitorDataStorageSqliteError
             .failed(message: message)
         } catch let error {
@@ -426,6 +431,28 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
         }
     }
 
+    // MARK: - vacuum
+
+    @objc func vacuum() throws {
+
+        if mDb != nil {
+            do {
+                try mDb?.vacuum()
+                return
+            } catch StorageHelperError.vacuum(let message) {
+                throw CapgoCapacitorDataStorageSqliteError
+                .failed(message: message)
+            } catch let error {
+                throw CapgoCapacitorDataStorageSqliteError
+                .failed(message: error.localizedDescription)
+            }
+        } else {
+            let message = "Must open a store first"
+            throw CapgoCapacitorDataStorageSqliteError
+            .failed(message: message)
+        }
+    }
+
     // MARK: - isJsonValid
 
     @objc func isJsonValid(_ parsingData: String) throws {
@@ -472,7 +499,8 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
                     mDb = try StorageDatabaseHelper(
                         databaseName: "\(dbName)SQLite.db",
                         tableName: table.name,
-                        encrypted: encrypted, mode: mode)
+                        encrypted: encrypted, mode: mode,
+                        autoVacuum: nil)
                     if !(mDb.isOpen ) {
                         throw CapgoCapacitorDataStorageSqliteError
                         .failed(message: "store not opened")

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlitePlugin.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlitePlugin.swift
@@ -30,6 +30,7 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin 
         CAPPluginMethod(name: "isJsonValid", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "importFromJson", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "exportToJson", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "vacuum", returnType: CAPPluginReturnPromise),
         CAPPluginMethod(name: "getPluginVersion", returnType: CAPPluginReturnPromise)
     ]
     private let implementation = CapgoCapacitorDataStorageSqlite()
@@ -41,6 +42,7 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin 
         let dbName = call.options["database"] as? String ?? "storage"
         let tableName = call.options["table"] as? String ?? "storage_table"
         let encrypted = call.options["encrypted"] as? Bool ?? false
+        let autoVacuum = call.options["autoVacuum"].map { "\($0)" }
         var inMode: String = ""
         if encrypted {
             inMode = call.options["mode"] as? String ?? "no-encryption"
@@ -60,7 +62,8 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin 
             try implementation
                 .openStore(dbName,
                            tableName: tableName,
-                           encrypted: encrypted, inMode: inMode)
+                           encrypted: encrypted, inMode: inMode,
+                           autoVacuum: autoVacuum)
             retHandler.rResult(call: call)
             return
         } catch CapgoCapacitorDataStorageSqliteError
@@ -561,6 +564,22 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin 
             return
         }
 
+    }
+
+    @objc func vacuum(_ call: CAPPluginCall) {
+        do {
+            try implementation.vacuum()
+            retHandler.rResult(call: call)
+            return
+        } catch CapgoCapacitorDataStorageSqliteError.failed(let message) {
+            let msg = "vacuum: \(message)"
+            retHandler.rResult(call: call, message: msg)
+            return
+        } catch let error {
+            let msg = "vacuum: \(error.localizedDescription)"
+            retHandler.rResult(call: call, message: msg)
+            return
+        }
     }
 
     @objc func getPluginVersion(_ call: CAPPluginCall) {

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/StorageDatabaseHelper.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/StorageDatabaseHelper.swift
@@ -39,6 +39,8 @@ enum StorageHelperError: Error {
     case isTable(message: String)
     case tables(message: String)
     case deleteTable(message: String)
+    case autoVacuum(message: String)
+    case vacuum(message: String)
     case importFromJson(message: String)
     case exportToJson(message: String)
 }
@@ -51,6 +53,7 @@ class StorageDatabaseHelper {
     var encrypted: Bool
     var dbName: String
     var mode: String
+    var autoVacuum: String?
     // define the path for the database
     var path: String = ""
     var globalData: Global = Global()
@@ -58,9 +61,10 @@ class StorageDatabaseHelper {
     // MARK: - Init
 
     init(databaseName: String, tableName: String, encrypted: Bool,
-         mode: String) throws {
+         mode: String, autoVacuum: String?) throws {
         self.tableName = tableName
         self.mode = mode
+        self.autoVacuum = autoVacuum
         self.encrypted = encrypted
         self.dbName = databaseName
         do {
@@ -128,6 +132,7 @@ class StorageDatabaseHelper {
                                       readonly: false)
             if mDB != nil {
                 isOpen = true
+                try configureAutoVacuum()
                 try setTable(tblName: self.tableName)
                 return
             } else {
@@ -135,6 +140,9 @@ class StorageDatabaseHelper {
                 throw StorageHelperError.open(message: "No store returned" )
             }
         } catch StorageHelperError.setTable(let message) {
+            isOpen = false
+            throw StorageHelperError.open(message: message )
+        } catch StorageHelperError.autoVacuum(let message) {
             isOpen = false
             throw StorageHelperError.open(message: message )
         } catch UtilsSQLCipherError.openOrCreateDatabase(let message) {
@@ -145,6 +153,60 @@ class StorageDatabaseHelper {
         }
     }
     // swiftlint:enable function_body_length
+
+    private func normalizeAutoVacuumMode() throws -> Int? {
+        guard let autoVacuum = autoVacuum?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !autoVacuum.isEmpty else {
+            return nil
+        }
+        switch autoVacuum.lowercased() {
+        case "0", "none":
+            return 0
+        case "1", "full":
+            return 1
+        case "2", "incremental":
+            return 2
+        default:
+            throw StorageHelperError
+                .autoVacuum(message: "autoVacuum must be one of none, full, incremental, 0, 1, or 2")
+        }
+    }
+
+    private func getAutoVacuumMode() throws -> Int {
+        guard let mDB = mDB else {
+            throw StorageHelperError.autoVacuum(message: "No store returned")
+        }
+        var statement: OpaquePointer?
+        let prepareCode = sqlite3_prepare_v2(mDB, "PRAGMA auto_vacuum;", -1, &statement, nil)
+        if prepareCode != SQLITE_OK {
+            let msg = String(cString: sqlite3_errmsg(mDB))
+            throw StorageHelperError.autoVacuum(message: msg)
+        }
+        defer {
+            sqlite3_finalize(statement)
+        }
+        if sqlite3_step(statement) == SQLITE_ROW {
+            return Int(sqlite3_column_int(statement, 0))
+        }
+        return 0
+    }
+
+    private func configureAutoVacuum() throws {
+        guard let mode = try normalizeAutoVacuumMode() else {
+            return
+        }
+        let currentMode = try getAutoVacuumMode()
+        if currentMode != mode {
+            do {
+                try UtilsSQLCipher.execute(mDB: self,
+                                           sql: "PRAGMA auto_vacuum = \(mode);")
+                try UtilsSQLCipher.execute(mDB: self, sql: "VACUUM;")
+            } catch UtilsSQLCipherError.execute(let message) {
+                throw StorageHelperError.autoVacuum(message: message)
+            }
+        }
+    }
+
     // MARK: - Close
 
     func close() throws {
@@ -542,6 +604,19 @@ class StorageDatabaseHelper {
             .deleteTable(message: error.localizedDescription)
         }
 
+    }
+
+    // MARK: - Vacuum
+
+    func vacuum() throws {
+        do {
+            try UtilsSQLCipher.execute(mDB: self, sql: "VACUUM;")
+            return
+        } catch UtilsSQLCipherError.execute(let message) {
+            throw StorageHelperError.vacuum(message: message)
+        } catch let error {
+            throw StorageHelperError.vacuum(message: error.localizedDescription)
+        }
     }
 
     // MARK: - ImportFromJson

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -142,6 +142,13 @@ export interface CapgoCapacitorDataStorageSqlitePlugin {
   exportToJson(): Promise<capStoreJson>;
 
   /**
+   * Rebuild the current SQLite store to reclaim unused disk space.
+   * @returns Promise<void>
+   * @since 8.0.32
+   */
+  vacuum(): Promise<void>;
+
+  /**
    * Get the native Capacitor plugin version
    *
    * @returns {Promise<{ version: string }>} a Promise with version for this plugin
@@ -172,7 +179,15 @@ export interface capOpenStorageOptions {
    * ["encryption", "secret","newsecret"]
    */
   mode?: string; // only for ios and android
+  /**
+   * Set the SQLite auto_vacuum mode for the store.
+   *
+   * Use `none`/`0`, `full`/`1`, or `incremental`/`2`.
+   * iOS, Android, and Electron only. Web ignores this option.
+   */
+  autoVacuum?: capSQLiteAutoVacuum;
 }
+export type capSQLiteAutoVacuum = 'none' | 'full' | 'incremental' | 0 | 1 | 2;
 export interface capDataStorageOptions {
   /**
    * The data name

--- a/src/web.ts
+++ b/src/web.ts
@@ -285,6 +285,10 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     }
   }
 
+  async vacuum(): Promise<void> {
+    return Promise.resolve();
+  }
+
   async getPluginVersion(): Promise<{ version: string }> {
     return { version: 'web' };
   }


### PR DESCRIPTION
## What
- Add a `vacuum()` API to rebuild the active SQLite store and reclaim unused disk space.
- Add `autoVacuum` support on `openStore()` for Android, iOS, and Electron.
- Document the new API and option in the generated README API section.

## Why
- Fixes #72. SQLite deletes rows logically but does not shrink the database file unless VACUUM runs or auto_vacuum is configured.

## How
- Normalize `autoVacuum` values (`none`/`0`, `full`/`1`, `incremental`/`2`) per platform.
- Apply `PRAGMA auto_vacuum` before table creation and run `VACUUM` when the mode changes.
- Expose explicit `vacuum()` calls on native/Electron implementations, with a web no-op for API compatibility.

## Testing
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/bin:/Users/martindonadieu/Library/Android/sdk/platform-tools:$PATH bun run verify`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ANDROID_HOME=/Users/martindonadieu/Library/Android/sdk PATH=/opt/homebrew/opt/openjdk@21/bin:/Users/martindonadieu/Library/Android/sdk/platform-tools:$PATH bun run lint`

## Not Tested
- Manual device-level disk-size measurement after deleting rows and calling `vacuum()`.