### PR TITLE
feat: add storage key change listeners

### DIFF
--- a/.github/scripts/verify-packed-example.sh
+++ b/.github/scripts/verify-packed-example.sh
@@ -38,15 +38,23 @@ bun remove "$plugin_name"
 bun add "${packed_packages[0]}"
 bun run build
 
+ensure_platform() {
+  local platform="$1"
+
+  if [ ! -d "$platform" ]; then
+    bunx cap add "$platform"
+  fi
+}
+
 case "$platform" in
   android)
-    bunx cap add android
+    ensure_platform android
     bunx cap sync android
     cd android
     ./gradlew build test
     ;;
   ios)
-    bunx cap add ios
+    ensure_platform ios
     bunx cap sync ios
     xcodebuild -project ios/App/App.xcodeproj -scheme App -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO
     ;;

--- a/README.md
+++ b/README.md
@@ -214,6 +214,45 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- prettier-ignore-end -->
 
 
+## Native key change listeners
+
+Native iOS and Android code can subscribe to storage key changes without keeping the WebView running. This is useful for app extensions, CarPlay, Android Auto, widgets, and other native entry points that need to react when web code updates persisted storage.
+
+Listeners are called on the main thread after `set`, `remove`, `clear`, `deleteTable` for the current table, and `importFromJson` changes. The event includes `database`, `table`, `key`, `value`, and `deleted`. `value` is omitted when `deleted` is true.
+
+Android:
+
+```java
+CapgoCapacitorDataStorageSqlite.addChangeListener(change -> {
+    if ("settings".equals(change.getKey()) && !change.isDeleted()) {
+        String value = change.getValue();
+    }
+});
+```
+
+iOS:
+
+```swift
+final class StorageObserver: NSObject, CapgoDataStorageChangeListener {
+    func onDataStorageChange(_ change: CapgoCapacitorDataStorageSqliteChange) {
+        if change.key == "settings", !change.deleted {
+            let value = change.value
+        }
+    }
+}
+
+let observer = StorageObserver()
+CapgoCapacitorDataStorageSqlite.addChangeListener(observer)
+```
+
+JavaScript can also listen to one key by using the key as the event name:
+
+```typescript
+const handle = await CapgoCapacitorDataStorageSqlite.addListener('settings', (change) => {
+  console.log(change.value)
+})
+```
+
 <docgen-index>
 
 * [`openStore(...)`](#openstore)
@@ -238,6 +277,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 * [`isJsonValid(...)`](#isjsonvalid)
 * [`exportToJson()`](#exporttojson)
 * [`vacuum()`](#vacuum)
+* [`addListener(string, ...)`](#addlistenerstring-)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -619,6 +659,30 @@ Rebuild the current SQLite store to reclaim unused disk space.
 --------------------
 
 
+### addListener(string, ...)
+
+```typescript
+addListener(eventName: string, listenerFunc: capDataStorageChangeListener) => Promise<PluginListenerHandle>
+```
+
+Listen for changes to one storage key.
+
+The listener event name is the storage key to observe. When that key is
+set, the listener receives the key and latest value. When the key is
+removed or cleared, `deleted` is true and `value` is omitted.
+
+| Param              | Type                                                                                  | Description                 |
+| ------------------ | ------------------------------------------------------------------------------------- | --------------------------- |
+| **`eventName`**    | <code>string</code>                                                                   | storage key to observe      |
+| **`listenerFunc`** | <code><a href="#capdatastoragechangelistener">capDataStorageChangeListener</a></code> | storage key change listener |
+
+**Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
+
+**Since:** 8.0.35
+
+--------------------
+
+
 ### getPluginVersion()
 
 ```typescript
@@ -756,12 +820,35 @@ Get the native Capacitor plugin version
 | **`values`** | <code>capDataStorageOptions[]</code> | * Array of Values (<a href="#capdatastorageoptions">capDataStorageOptions</a>) |
 
 
+#### PluginListenerHandle
+
+| Prop         | Type                                      |
+| ------------ | ----------------------------------------- |
+| **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
+
+
+#### capDataStorageChangeEvent
+
+| Prop           | Type                 | Description                                   |
+| -------------- | -------------------- | --------------------------------------------- |
+| **`database`** | <code>string</code>  | The storage database that changed.            |
+| **`table`**    | <code>string</code>  | The storage table that changed.               |
+| **`key`**      | <code>string</code>  | The storage key that changed.                 |
+| **`value`**    | <code>string</code>  | The latest value for the key when it was set. |
+| **`deleted`**  | <code>boolean</code> | True when the key was removed or cleared.     |
+
+
 ### Type Aliases
 
 
 #### capSQLiteAutoVacuum
 
 <code>'none' | 'full' | 'incremental' | 0 | 1 | 2</code>
+
+
+#### capDataStorageChangeListener
+
+<code>(event: <a href="#capdatastoragechangeevent">capDataStorageChangeEvent</a>): void</code>
 
 </docgen-api>
 

--- a/README.md
+++ b/README.md
@@ -223,11 +223,16 @@ Listeners are called on the main thread after `set`, `remove`, `clear`, `deleteT
 Android:
 
 ```java
-CapgoCapacitorDataStorageSqlite.addChangeListener(change -> {
+CapgoCapacitorDataStorageSqlite.DataStorageChangeListener listener = change -> {
     if ("settings".equals(change.getKey()) && !change.isDeleted()) {
         String value = change.getValue();
     }
-});
+};
+
+CapgoCapacitorDataStorageSqlite.addChangeListener(listener);
+
+// Later, when done listening:
+CapgoCapacitorDataStorageSqlite.removeChangeListener(listener);
 ```
 
 iOS:
@@ -243,14 +248,20 @@ final class StorageObserver: NSObject, CapgoDataStorageChangeListener {
 
 let observer = StorageObserver()
 CapgoCapacitorDataStorageSqlite.addChangeListener(observer)
+
+// Later, when done listening:
+CapgoCapacitorDataStorageSqlite.removeChangeListener(observer)
 ```
 
 JavaScript can also listen to one key by using the key as the event name:
 
 ```typescript
 const handle = await CapgoCapacitorDataStorageSqlite.addListener('settings', (change) => {
-  console.log(change.value)
-})
+  console.log(change.value);
+});
+
+// Later, when done listening:
+await handle.remove();
 ```
 
 <docgen-index>
@@ -827,17 +838,6 @@ Get the native Capacitor plugin version
 | **`remove`** | <code>() =&gt; Promise&lt;void&gt;</code> |
 
 
-#### capDataStorageChangeEvent
-
-| Prop           | Type                 | Description                                   |
-| -------------- | -------------------- | --------------------------------------------- |
-| **`database`** | <code>string</code>  | The storage database that changed.            |
-| **`table`**    | <code>string</code>  | The storage table that changed.               |
-| **`key`**      | <code>string</code>  | The storage key that changed.                 |
-| **`value`**    | <code>string</code>  | The latest value for the key when it was set. |
-| **`deleted`**  | <code>boolean</code> | True when the key was removed or cleared.     |
-
-
 ### Type Aliases
 
 
@@ -849,6 +849,11 @@ Get the native Capacitor plugin version
 #### capDataStorageChangeListener
 
 <code>(event: <a href="#capdatastoragechangeevent">capDataStorageChangeEvent</a>): void</code>
+
+
+#### capDataStorageChangeEvent
+
+<code>{ /** * The storage database that changed. */ database?: string; /** * The storage table that changed. */ table?: string; /** * The storage key that changed. */ key: string; /** * The latest value for the key when it was set. */ value: string; /** * False or omitted when the key was set. */ deleted?: false; } | { /** * The storage database that changed. */ database?: string; /** * The storage table that changed. */ table?: string; /** * The storage key that changed. */ key: string; /** * Omitted when the key was removed or cleared. */ value?: never; /** * True when the key was removed or cleared. */ deleted: true; }</code>
 
 </docgen-api>
 

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
@@ -1,22 +1,137 @@
 package com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite;
 
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import com.getcapacitor.JSObject;
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.Data;
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.ImportExportJson.JsonStore;
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.ImportExportJson.JsonTable;
+import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.ImportExportJson.JsonValue;
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.StorageDatabaseHelper;
 import java.io.File;
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
 public class CapgoCapacitorDataStorageSqlite {
+
+    private static final String SQLITE_SUFFIX = "SQLite.db";
+    private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
+    private static final List<WeakReference<DataStorageChangeListener>> dataStorageChangeListeners = new ArrayList<>();
+
+    public interface DataStorageChangeListener {
+        void onDataStorageChange(DataStorageChange change);
+    }
+
+    public static class DataStorageChange {
+
+        private final String database;
+        private final String table;
+        private final String key;
+        private final String value;
+        private final boolean deleted;
+
+        public DataStorageChange(String database, String table, String key, String value, boolean deleted) {
+            this.database = database;
+            this.table = table;
+            this.key = key;
+            this.value = value;
+            this.deleted = deleted;
+        }
+
+        public String getDatabase() {
+            return database;
+        }
+
+        public String getTable() {
+            return table;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public boolean isDeleted() {
+            return deleted;
+        }
+
+        public JSObject toJSObject() {
+            JSObject ret = new JSObject();
+            ret.put("database", database);
+            ret.put("table", table);
+            ret.put("key", key);
+            if (value != null) {
+                ret.put("value", value);
+            }
+            if (deleted) {
+                ret.put("deleted", true);
+            }
+            return ret;
+        }
+    }
+
+    public static synchronized void addChangeListener(DataStorageChangeListener listener) {
+        if (listener == null) {
+            return;
+        }
+        removeChangeListener(listener);
+        dataStorageChangeListeners.add(new WeakReference<>(listener));
+    }
+
+    public static synchronized void removeChangeListener(DataStorageChangeListener listener) {
+        dataStorageChangeListeners.removeIf((ref) -> {
+            DataStorageChangeListener value = ref.get();
+            return value == null || value == listener;
+        });
+    }
+
+    private static void notifyDataStorageChange(DataStorageChange change) {
+        MAIN_HANDLER.post(() -> {
+            List<DataStorageChangeListener> snapshot = new ArrayList<>();
+            synchronized (CapgoCapacitorDataStorageSqlite.class) {
+                dataStorageChangeListeners.removeIf((ref) -> ref.get() == null);
+                for (WeakReference<DataStorageChangeListener> ref : dataStorageChangeListeners) {
+                    DataStorageChangeListener listener = ref.get();
+                    if (listener != null) {
+                        snapshot.add(listener);
+                    }
+                }
+            }
+            for (DataStorageChangeListener listener : snapshot) {
+                listener.onDataStorageChange(change);
+            }
+        });
+    }
 
     private StorageDatabaseHelper mDb;
     private Context context;
 
     public CapgoCapacitorDataStorageSqlite(Context context) {
         this.context = context;
+    }
+
+    private String getCurrentDatabaseName() {
+        if (mDb == null) {
+            return "";
+        }
+        String storeName = mDb.getStoreName();
+        if (storeName.endsWith(SQLITE_SUFFIX)) {
+            return storeName.substring(0, storeName.length() - SQLITE_SUFFIX.length());
+        }
+        return storeName;
+    }
+
+    private String getCurrentTableName() {
+        return mDb != null ? mDb.getTableName() : "";
+    }
+
+    private void notifyCurrentDataStorageChange(String key, String value, boolean deleted) {
+        notifyDataStorageChange(new DataStorageChange(getCurrentDatabaseName(), getCurrentTableName(), key, value, deleted));
     }
 
     public void openStore(String dbName, String tableName, Boolean encrypted, String inMode, int version, String autoVacuum)
@@ -68,6 +183,7 @@ public class CapgoCapacitorDataStorageSqlite {
                 data.name = key;
                 data.value = value;
                 mDb.set(data);
+                notifyCurrentDataStorageChange(key, value, false);
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -98,6 +214,7 @@ public class CapgoCapacitorDataStorageSqlite {
         if (mDb != null && mDb.isOpen) {
             try {
                 mDb.remove(name);
+                notifyCurrentDataStorageChange(name, null, true);
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -110,7 +227,11 @@ public class CapgoCapacitorDataStorageSqlite {
     public void clear() throws Exception {
         if (mDb != null && mDb.isOpen) {
             try {
+                List<String> keys = mDb.keys();
                 mDb.clear();
+                for (String key : keys) {
+                    notifyCurrentDataStorageChange(key, null, true);
+                }
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -241,7 +362,11 @@ public class CapgoCapacitorDataStorageSqlite {
     public void deleteTable(String table) throws Exception {
         if (mDb != null && mDb.isOpen) {
             try {
+                List<String> keys = mDb.getTableName().equals(table) ? mDb.keys() : new ArrayList<>();
                 mDb.deleteTable(table);
+                for (String key : keys) {
+                    notifyCurrentDataStorageChange(key, null, true);
+                }
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -331,6 +456,11 @@ public class CapgoCapacitorDataStorageSqlite {
                             throw new Exception("changes < 1");
                         } else {
                             totalChanges += changes;
+                            for (JsonValue value : table.getValues()) {
+                                notifyDataStorageChange(
+                                    new DataStorageChange(dbName, table.getName(), value.getKey(), value.getValue(), false)
+                                );
+                            }
                         }
                     } else {
                         throw new Exception("mDb is not opened");

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
@@ -87,13 +87,24 @@ public class CapgoCapacitorDataStorageSqlite {
     }
 
     private static void notifyDataStorageChange(DataStorageChange change) {
+        List<DataStorageChange> changes = new ArrayList<>();
+        changes.add(change);
+        notifyDataStorageChanges(changes);
+    }
+
+    private static void notifyDataStorageChanges(List<DataStorageChange> changes) {
+        if (changes.isEmpty()) {
+            return;
+        }
         MAIN_HANDLER.post(() -> {
             List<DataStorageChangeListener> snapshot = new ArrayList<>();
             synchronized (CapgoCapacitorDataStorageSqlite.class) {
                 snapshot.addAll(dataStorageChangeListeners);
             }
-            for (DataStorageChangeListener listener : snapshot) {
-                listener.onDataStorageChange(change);
+            for (DataStorageChange change : changes) {
+                for (DataStorageChangeListener listener : snapshot) {
+                    listener.onDataStorageChange(change);
+                }
             }
         });
     }
@@ -120,8 +131,20 @@ public class CapgoCapacitorDataStorageSqlite {
         return mDb != null ? mDb.getTableName() : "";
     }
 
+    private DataStorageChange createCurrentDataStorageChange(String key, String value, boolean deleted) {
+        return new DataStorageChange(getCurrentDatabaseName(), getCurrentTableName(), key, value, deleted);
+    }
+
     private void notifyCurrentDataStorageChange(String key, String value, boolean deleted) {
-        notifyDataStorageChange(new DataStorageChange(getCurrentDatabaseName(), getCurrentTableName(), key, value, deleted));
+        notifyDataStorageChange(createCurrentDataStorageChange(key, value, deleted));
+    }
+
+    private List<DataStorageChange> createCurrentDataStorageChanges(List<String> keys, String value, boolean deleted) {
+        List<DataStorageChange> changes = new ArrayList<>();
+        for (String key : keys) {
+            changes.add(createCurrentDataStorageChange(key, value, deleted));
+        }
+        return changes;
     }
 
     public void openStore(String dbName, String tableName, Boolean encrypted, String inMode, int version, String autoVacuum)
@@ -203,8 +226,11 @@ public class CapgoCapacitorDataStorageSqlite {
     public void remove(String name) throws Exception {
         if (mDb != null && mDb.isOpen) {
             try {
+                boolean existed = mDb.iskey(name);
                 mDb.remove(name);
-                notifyCurrentDataStorageChange(name, null, true);
+                if (existed) {
+                    notifyCurrentDataStorageChange(name, null, true);
+                }
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -217,11 +243,9 @@ public class CapgoCapacitorDataStorageSqlite {
     public void clear() throws Exception {
         if (mDb != null && mDb.isOpen) {
             try {
-                List<String> keys = mDb.keys();
+                List<DataStorageChange> changes = createCurrentDataStorageChanges(mDb.keys(), null, true);
                 mDb.clear();
-                for (String key : keys) {
-                    notifyCurrentDataStorageChange(key, null, true);
-                }
+                notifyDataStorageChanges(changes);
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -352,11 +376,11 @@ public class CapgoCapacitorDataStorageSqlite {
     public void deleteTable(String table) throws Exception {
         if (mDb != null && mDb.isOpen) {
             try {
-                List<String> keys = mDb.getTableName().equals(table) ? mDb.keys() : new ArrayList<>();
+                List<DataStorageChange> changes = mDb.getTableName().equals(table)
+                    ? createCurrentDataStorageChanges(mDb.keys(), null, true)
+                    : new ArrayList<>();
                 mDb.deleteTable(table);
-                for (String key : keys) {
-                    notifyCurrentDataStorageChange(key, null, true);
-                }
+                notifyDataStorageChanges(changes);
                 return;
             } catch (Exception e) {
                 throw new Exception(e.getMessage());
@@ -446,11 +470,13 @@ public class CapgoCapacitorDataStorageSqlite {
                             throw new Exception("changes < 1");
                         } else {
                             totalChanges += changes;
+                            List<DataStorageChange> importedChanges = new ArrayList<>();
                             for (JsonValue value : table.getValues()) {
-                                notifyDataStorageChange(
+                                importedChanges.add(
                                     new DataStorageChange(dbName, table.getName(), value.getKey(), value.getValue(), false)
                                 );
                             }
+                            notifyDataStorageChanges(importedChanges);
                         }
                     } else {
                         throw new Exception("mDb is not opened");

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java
@@ -10,7 +10,6 @@ import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.Impor
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.ImportExportJson.JsonValue;
 import com.jeep.plugin.capacitor.capgocapacitordatastoragesqlite.cdssUtils.StorageDatabaseHelper;
 import java.io.File;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +17,7 @@ public class CapgoCapacitorDataStorageSqlite {
 
     private static final String SQLITE_SUFFIX = "SQLite.db";
     private static final Handler MAIN_HANDLER = new Handler(Looper.getMainLooper());
-    private static final List<WeakReference<DataStorageChangeListener>> dataStorageChangeListeners = new ArrayList<>();
+    private static final List<DataStorageChangeListener> dataStorageChangeListeners = new ArrayList<>();
 
     public interface DataStorageChangeListener {
         void onDataStorageChange(DataStorageChange change);
@@ -80,27 +79,18 @@ public class CapgoCapacitorDataStorageSqlite {
             return;
         }
         removeChangeListener(listener);
-        dataStorageChangeListeners.add(new WeakReference<>(listener));
+        dataStorageChangeListeners.add(listener);
     }
 
     public static synchronized void removeChangeListener(DataStorageChangeListener listener) {
-        dataStorageChangeListeners.removeIf((ref) -> {
-            DataStorageChangeListener value = ref.get();
-            return value == null || value == listener;
-        });
+        dataStorageChangeListeners.removeIf((value) -> value == listener);
     }
 
     private static void notifyDataStorageChange(DataStorageChange change) {
         MAIN_HANDLER.post(() -> {
             List<DataStorageChangeListener> snapshot = new ArrayList<>();
             synchronized (CapgoCapacitorDataStorageSqlite.class) {
-                dataStorageChangeListeners.removeIf((ref) -> ref.get() == null);
-                for (WeakReference<DataStorageChangeListener> ref : dataStorageChangeListeners) {
-                    DataStorageChangeListener listener = ref.get();
-                    if (listener != null) {
-                        snapshot.add(listener);
-                    }
-                }
+                snapshot.addAll(dataStorageChangeListeners);
             }
             for (DataStorageChangeListener listener : snapshot) {
                 listener.onDataStorageChange(change);

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java
@@ -9,7 +9,7 @@ import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
 @CapacitorPlugin(name = "CapgoCapacitorDataStorageSqlite")
-public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin {
+public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin implements CapgoCapacitorDataStorageSqlite.DataStorageChangeListener {
 
     private final String pluginVersion = "8.0.34";
 
@@ -24,6 +24,7 @@ public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin {
     public void load() {
         context = getContext();
         implementation = new CapgoCapacitorDataStorageSqlite(context);
+        CapgoCapacitorDataStorageSqlite.addChangeListener(this);
     }
 
     @PluginMethod
@@ -456,5 +457,10 @@ public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin {
         } catch (final Exception e) {
             call.reject("Could not get plugin version", e);
         }
+    }
+
+    @Override
+    public void onDataStorageChange(CapgoCapacitorDataStorageSqlite.DataStorageChange change) {
+        notifyListeners(change.getKey(), change.toJSObject());
     }
 }

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java
@@ -27,6 +27,12 @@ public class CapgoCapacitorDataStorageSqlitePlugin extends Plugin implements Cap
         CapgoCapacitorDataStorageSqlite.addChangeListener(this);
     }
 
+    @Override
+    protected void handleOnDestroy() {
+        CapgoCapacitorDataStorageSqlite.removeChangeListener(this);
+        super.handleOnDestroy();
+    }
+
     @PluginMethod
     public void openStore(PluginCall call) {
         String dbName = call.getString("database", "storage");

--- a/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
+++ b/android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java
@@ -87,6 +87,15 @@ public class StorageDatabaseHelper {
     }
 
     /**
+     * GetTableName
+     * Return the current table name
+     * @return
+     */
+    public String getTableName() {
+        return this._tableName;
+    }
+
+    /**
      * Open Method
      * Open the store
      */

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
@@ -44,31 +44,68 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
 @objc public class CapgoCapacitorDataStorageSqlite: NSObject {
     private static let sqliteSuffix = "SQLite.db"
     private static let changeLock = NSRecursiveLock()
-    private static var changeListeners: [CapgoDataStorageChangeListener] = []
+    private static var changeListeners: [ChangeListenerEntry] = []
+
+    private final class ChangeListenerEntry {
+        let strongValue: CapgoDataStorageChangeListener?
+        weak var weakValue: CapgoDataStorageChangeListener?
+
+        var value: CapgoDataStorageChangeListener? {
+            strongValue ?? weakValue
+        }
+
+        init(_ value: CapgoDataStorageChangeListener, retained: Bool) {
+            if retained {
+                self.strongValue = value
+                self.weakValue = nil
+            } else {
+                self.strongValue = nil
+                self.weakValue = value
+            }
+        }
+    }
 
     var mDb: StorageDatabaseHelper?
 
     @objc public static func addChangeListener(_ listener: CapgoDataStorageChangeListener) {
+        addChangeListener(listener, retained: true)
+    }
+
+    static func addWeakChangeListener(_ listener: CapgoDataStorageChangeListener) {
+        addChangeListener(listener, retained: false)
+    }
+
+    private static func addChangeListener(_ listener: CapgoDataStorageChangeListener, retained: Bool) {
         changeLock.lock()
         defer { changeLock.unlock() }
-        changeListeners.removeAll { $0 === listener }
-        changeListeners.append(listener)
+        changeListeners.removeAll { $0.value == nil || $0.value === listener }
+        changeListeners.append(ChangeListenerEntry(listener, retained: retained))
     }
 
     @objc public static func removeChangeListener(_ listener: CapgoDataStorageChangeListener) {
         changeLock.lock()
         defer { changeLock.unlock() }
-        changeListeners.removeAll { $0 === listener }
+        changeListeners.removeAll { $0.value == nil || $0.value === listener }
     }
 
     private static func notifyDataStorageChange(_ change: CapgoCapacitorDataStorageSqliteChange) {
+        notifyDataStorageChanges([change])
+    }
+
+    private static func notifyDataStorageChanges(_ changes: [CapgoCapacitorDataStorageSqliteChange]) {
+        guard !changes.isEmpty else {
+            return
+        }
         DispatchQueue.main.async {
             changeLock.lock()
-            let snapshot = changeListeners
+            changeListeners.removeAll { $0.value == nil }
+            let snapshot = changeListeners.compactMap { $0.value }
             changeLock.unlock()
 
-            for listener in snapshot {
-                listener.onDataStorageChange(change)
+            for change in changes {
+                for listener in snapshot {
+                    listener.onDataStorageChange(change)
+                }
             }
         }
     }
@@ -83,28 +120,32 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
         return dbName
     }
 
-    private func notifyCurrentDataStorageChange(key: String, value: String?, deleted: Bool) {
-        Self.notifyDataStorageChange(
-            CapgoCapacitorDataStorageSqliteChange(
-                database: currentDatabaseName(),
-                table: mDb?.tableName ?? "",
-                key: key,
-                value: value,
-                deleted: deleted
-            )
+    private func currentDataStorageChange(key: String, value: String?, deleted: Bool) -> CapgoCapacitorDataStorageSqliteChange {
+        CapgoCapacitorDataStorageSqliteChange(
+            database: currentDatabaseName(),
+            table: mDb?.tableName ?? "",
+            key: key,
+            value: value,
+            deleted: deleted
         )
     }
 
-    private static func notifyImportedValues(database: String, table: JsonTable) {
-        for value in table.values {
-            notifyDataStorageChange(
-                CapgoCapacitorDataStorageSqliteChange(
-                    database: database,
-                    table: table.name,
-                    key: value.key,
-                    value: value.value,
-                    deleted: false
-                )
+    private func notifyCurrentDataStorageChange(key: String, value: String?, deleted: Bool) {
+        Self.notifyDataStorageChange(currentDataStorageChange(key: key, value: value, deleted: deleted))
+    }
+
+    private func currentDataStorageChanges(keys: [String], value: String?, deleted: Bool) -> [CapgoCapacitorDataStorageSqliteChange] {
+        keys.map { currentDataStorageChange(key: $0, value: value, deleted: deleted) }
+    }
+
+    private static func importedChanges(database: String, table: JsonTable) -> [CapgoCapacitorDataStorageSqliteChange] {
+        table.values.map {
+            CapgoCapacitorDataStorageSqliteChange(
+                database: database,
+                table: table.name,
+                key: $0.key,
+                value: $0.value,
+                deleted: false
             )
         }
     }
@@ -284,8 +325,11 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
     @objc func remove(_ name: String) throws {
         if mDb != nil {
             do {
+                let existed = try mDb?.iskey(name: name) ?? false
                 try mDb?.remove(name: name)
-                notifyCurrentDataStorageChange(key: name, value: nil, deleted: true)
+                if existed {
+                    notifyCurrentDataStorageChange(key: name, value: nil, deleted: true)
+                }
                 return
             } catch StorageHelperError.remove(let message) {
                 throw CapgoCapacitorDataStorageSqliteError
@@ -308,11 +352,9 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
     @objc func clear() throws {
         if mDb != nil {
             do {
-                let keys = try mDb?.keys() ?? []
+                let changes = currentDataStorageChanges(keys: try mDb?.keys() ?? [], value: nil, deleted: true)
                 try mDb?.clear()
-                for key in keys {
-                    notifyCurrentDataStorageChange(key: key, value: nil, deleted: true)
-                }
+                Self.notifyDataStorageChanges(changes)
                 return
             } catch StorageHelperError.clear(let message) {
                 throw CapgoCapacitorDataStorageSqliteError
@@ -523,11 +565,11 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
 
         if mDb != nil {
             do {
-                let keys = mDb?.tableName == tableName ? (try mDb?.keys() ?? []) : []
+                let changes = mDb?.tableName == tableName
+                    ? currentDataStorageChanges(keys: try mDb?.keys() ?? [], value: nil, deleted: true)
+                    : []
                 try mDb?.deleteTable(tableName: tableName)
-                for key in keys {
-                    notifyCurrentDataStorageChange(key: key, value: nil, deleted: true)
-                }
+                Self.notifyDataStorageChanges(changes)
                 return
             } catch StorageHelperError.deleteTable(let message) {
                 throw CapgoCapacitorDataStorageSqliteError
@@ -628,7 +670,7 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
                     }
                     try mDb.close()
                     totalChanges += changes
-                    Self.notifyImportedValues(database: dbName, table: table)
+                    Self.notifyDataStorageChanges(Self.importedChanges(database: dbName, table: table))
                 }
                 return ["changes": totalChanges]
             } catch StorageHelperError.initFailed(let message) {

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
@@ -4,10 +4,119 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
     case failed(message: String)
 }
 
+@objc public protocol CapgoDataStorageChangeListener: AnyObject {
+    func onDataStorageChange(_ change: CapgoCapacitorDataStorageSqliteChange)
+}
+
+@objc public class CapgoCapacitorDataStorageSqliteChange: NSObject {
+    @objc public let database: String
+    @objc public let table: String
+    @objc public let key: String
+    @objc public let value: String?
+    @objc public let deleted: Bool
+
+    @objc public init(database: String, table: String, key: String, value: String?, deleted: Bool) {
+        self.database = database
+        self.table = table
+        self.key = key
+        self.value = value
+        self.deleted = deleted
+    }
+
+    var dictionary: [String: Any] {
+        var ret: [String: Any] = [
+            "database": database,
+            "table": table,
+            "key": key
+        ]
+        if let value = value {
+            ret["value"] = value
+        }
+        if deleted {
+            ret["deleted"] = true
+        }
+        return ret
+    }
+}
+
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 @objc public class CapgoCapacitorDataStorageSqlite: NSObject {
+    private static let sqliteSuffix = "SQLite.db"
+    private static let changeLock = NSRecursiveLock()
+    private static var changeListeners: [WeakChangeListener] = []
+
+    private final class WeakChangeListener {
+        weak var value: CapgoDataStorageChangeListener?
+
+        init(_ value: CapgoDataStorageChangeListener) {
+            self.value = value
+        }
+    }
+
     var mDb: StorageDatabaseHelper?
+
+    @objc public static func addChangeListener(_ listener: CapgoDataStorageChangeListener) {
+        changeLock.lock()
+        defer { changeLock.unlock() }
+        changeListeners.removeAll { $0.value == nil || $0.value === listener }
+        changeListeners.append(WeakChangeListener(listener))
+    }
+
+    @objc public static func removeChangeListener(_ listener: CapgoDataStorageChangeListener) {
+        changeLock.lock()
+        defer { changeLock.unlock() }
+        changeListeners.removeAll { $0.value == nil || $0.value === listener }
+    }
+
+    private static func notifyDataStorageChange(_ change: CapgoCapacitorDataStorageSqliteChange) {
+        DispatchQueue.main.async {
+            changeLock.lock()
+            changeListeners.removeAll { $0.value == nil }
+            let snapshot = changeListeners.compactMap { $0.value }
+            changeLock.unlock()
+
+            for listener in snapshot {
+                listener.onDataStorageChange(change)
+            }
+        }
+    }
+
+    private func currentDatabaseName() -> String {
+        guard let dbName = mDb?.dbName else {
+            return ""
+        }
+        if dbName.hasSuffix(Self.sqliteSuffix) {
+            return String(dbName.dropLast(Self.sqliteSuffix.count))
+        }
+        return dbName
+    }
+
+    private func notifyCurrentDataStorageChange(key: String, value: String?, deleted: Bool) {
+        Self.notifyDataStorageChange(
+            CapgoCapacitorDataStorageSqliteChange(
+                database: currentDatabaseName(),
+                table: mDb?.tableName ?? "",
+                key: key,
+                value: value,
+                deleted: deleted
+            )
+        )
+    }
+
+    private static func notifyImportedValues(database: String, table: JsonTable) {
+        for value in table.values {
+            notifyDataStorageChange(
+                CapgoCapacitorDataStorageSqliteChange(
+                    database: database,
+                    table: table.name,
+                    key: value.key,
+                    value: value.value,
+                    deleted: false
+                )
+            )
+        }
+    }
 
     // MARK: - OpenStore
 
@@ -121,6 +230,9 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
             if let mData = data as? Data {
                 do {
                     try mDb?.set(data: mData)
+                    if let key = mData.name {
+                        notifyCurrentDataStorageChange(key: key, value: mData.value, deleted: false)
+                    }
                 } catch StorageHelperError.setkey(let message) {
                     throw CapgoCapacitorDataStorageSqliteError
                     .failed(message: message)
@@ -182,6 +294,7 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
         if mDb != nil {
             do {
                 try mDb?.remove(name: name)
+                notifyCurrentDataStorageChange(key: name, value: nil, deleted: true)
                 return
             } catch StorageHelperError.remove(let message) {
                 throw CapgoCapacitorDataStorageSqliteError
@@ -204,7 +317,11 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
     @objc func clear() throws {
         if mDb != nil {
             do {
+                let keys = try mDb?.keys() ?? []
                 try mDb?.clear()
+                for key in keys {
+                    notifyCurrentDataStorageChange(key: key, value: nil, deleted: true)
+                }
                 return
             } catch StorageHelperError.clear(let message) {
                 throw CapgoCapacitorDataStorageSqliteError
@@ -415,7 +532,11 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
 
         if mDb != nil {
             do {
+                let keys = mDb?.tableName == tableName ? (try mDb?.keys() ?? []) : []
                 try mDb?.deleteTable(tableName: tableName)
+                for key in keys {
+                    notifyCurrentDataStorageChange(key: key, value: nil, deleted: true)
+                }
                 return
             } catch StorageHelperError.deleteTable(let message) {
                 throw CapgoCapacitorDataStorageSqliteError
@@ -516,6 +637,7 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
                     }
                     try mDb.close()
                     totalChanges += changes
+                    Self.notifyImportedValues(database: dbName, table: table)
                 }
                 return ["changes": totalChanges]
             } catch StorageHelperError.initFailed(let message) {

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlite.swift
@@ -44,36 +44,27 @@ enum CapgoCapacitorDataStorageSqliteError: Error {
 @objc public class CapgoCapacitorDataStorageSqlite: NSObject {
     private static let sqliteSuffix = "SQLite.db"
     private static let changeLock = NSRecursiveLock()
-    private static var changeListeners: [WeakChangeListener] = []
-
-    private final class WeakChangeListener {
-        weak var value: CapgoDataStorageChangeListener?
-
-        init(_ value: CapgoDataStorageChangeListener) {
-            self.value = value
-        }
-    }
+    private static var changeListeners: [CapgoDataStorageChangeListener] = []
 
     var mDb: StorageDatabaseHelper?
 
     @objc public static func addChangeListener(_ listener: CapgoDataStorageChangeListener) {
         changeLock.lock()
         defer { changeLock.unlock() }
-        changeListeners.removeAll { $0.value == nil || $0.value === listener }
-        changeListeners.append(WeakChangeListener(listener))
+        changeListeners.removeAll { $0 === listener }
+        changeListeners.append(listener)
     }
 
     @objc public static func removeChangeListener(_ listener: CapgoDataStorageChangeListener) {
         changeLock.lock()
         defer { changeLock.unlock() }
-        changeListeners.removeAll { $0.value == nil || $0.value === listener }
+        changeListeners.removeAll { $0 === listener }
     }
 
     private static func notifyDataStorageChange(_ change: CapgoCapacitorDataStorageSqliteChange) {
         DispatchQueue.main.async {
             changeLock.lock()
-            changeListeners.removeAll { $0.value == nil }
-            let snapshot = changeListeners.compactMap { $0.value }
+            let snapshot = changeListeners
             changeLock.unlock()
 
             for listener in snapshot {

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlitePlugin.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlitePlugin.swift
@@ -37,7 +37,11 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin,
     private let retHandler: ReturnHandler = ReturnHandler()
 
     override public func load() {
-        CapgoCapacitorDataStorageSqlite.addChangeListener(self)
+        CapgoCapacitorDataStorageSqlite.addWeakChangeListener(self)
+    }
+
+    deinit {
+        CapgoCapacitorDataStorageSqlite.removeChangeListener(self)
     }
 
     // MARK: - OpenStore

--- a/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlitePlugin.swift
+++ b/ios/Sources/CapgoCapacitorDataStorageSqlitePlugin/CapgoCapacitorDataStorageSqlitePlugin.swift
@@ -4,7 +4,7 @@ import Capacitor
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
 @objc(CapgoCapacitorDataStorageSqlitePlugin)
-public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin {
+public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin, CapgoDataStorageChangeListener {
     private let pluginVersion: String = "8.0.34"
     public let identifier = "CapgoCapacitorDataStorageSqlitePlugin"
     public let jsName = "CapgoCapacitorDataStorageSqlite"
@@ -35,6 +35,10 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin 
     ]
     private let implementation = CapgoCapacitorDataStorageSqlite()
     private let retHandler: ReturnHandler = ReturnHandler()
+
+    override public func load() {
+        CapgoCapacitorDataStorageSqlite.addChangeListener(self)
+    }
 
     // MARK: - OpenStore
 
@@ -584,6 +588,10 @@ public class CapgoCapacitorDataStorageSqlitePlugin: CAPPlugin, CAPBridgedPlugin 
 
     @objc func getPluginVersion(_ call: CAPPluginCall) {
         call.resolve(["version": self.pluginVersion])
+    }
+
+    public func onDataStorageChange(_ change: CapgoCapacitorDataStorageSqliteChange) {
+        notifyListeners(change.key, data: change.dictionary)
     }
 
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -214,28 +214,51 @@ export interface capDataStorageOptions {
    */
   value?: string;
 }
-export interface capDataStorageChangeEvent {
-  /**
-   * The storage database that changed.
-   */
-  database?: string;
-  /**
-   * The storage table that changed.
-   */
-  table?: string;
-  /**
-   * The storage key that changed.
-   */
-  key: string;
-  /**
-   * The latest value for the key when it was set.
-   */
-  value?: string;
-  /**
-   * True when the key was removed or cleared.
-   */
-  deleted?: boolean;
-}
+export type capDataStorageChangeEvent =
+  | {
+      /**
+       * The storage database that changed.
+       */
+      database?: string;
+      /**
+       * The storage table that changed.
+       */
+      table?: string;
+      /**
+       * The storage key that changed.
+       */
+      key: string;
+      /**
+       * The latest value for the key when it was set.
+       */
+      value: string;
+      /**
+       * False or omitted when the key was set.
+       */
+      deleted?: false;
+    }
+  | {
+      /**
+       * The storage database that changed.
+       */
+      database?: string;
+      /**
+       * The storage table that changed.
+       */
+      table?: string;
+      /**
+       * The storage key that changed.
+       */
+      key: string;
+      /**
+       * Omitted when the key was removed or cleared.
+       */
+      value?: never;
+      /**
+       * True when the key was removed or cleared.
+       */
+      deleted: true;
+    };
 export type capDataStorageChangeListener = (event: capDataStorageChangeEvent) => void;
 export interface capStorageOptions {
   /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,5 @@
+import type { PluginListenerHandle } from '@capacitor/core';
+
 export interface CapgoCapacitorDataStorageSqlitePlugin {
   /**
    * Open a store
@@ -149,6 +151,20 @@ export interface CapgoCapacitorDataStorageSqlitePlugin {
   vacuum(): Promise<void>;
 
   /**
+   * Listen for changes to one storage key.
+   *
+   * The listener event name is the storage key to observe. When that key is
+   * set, the listener receives the key and latest value. When the key is
+   * removed or cleared, `deleted` is true and `value` is omitted.
+   *
+   * @param eventName storage key to observe
+   * @param listenerFunc storage key change listener
+   * @returns Promise<PluginListenerHandle>
+   * @since 8.0.35
+   */
+  addListener(eventName: string, listenerFunc: capDataStorageChangeListener): Promise<PluginListenerHandle>;
+
+  /**
    * Get the native Capacitor plugin version
    *
    * @returns {Promise<{ version: string }>} a Promise with version for this plugin
@@ -198,6 +214,29 @@ export interface capDataStorageOptions {
    */
   value?: string;
 }
+export interface capDataStorageChangeEvent {
+  /**
+   * The storage database that changed.
+   */
+  database?: string;
+  /**
+   * The storage table that changed.
+   */
+  table?: string;
+  /**
+   * The storage key that changed.
+   */
+  key: string;
+  /**
+   * The latest value for the key when it was set.
+   */
+  value?: string;
+  /**
+   * True when the key was removed or cleared.
+   */
+  deleted?: boolean;
+}
+export type capDataStorageChangeListener = (event: capDataStorageChangeEvent) => void;
 export interface capStorageOptions {
   /**
    * The storage name

--- a/src/web.ts
+++ b/src/web.ts
@@ -119,8 +119,11 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     const database = this.currentDatabase;
     const table = this.currentTable;
     try {
+      const existed = await this.mDb.iskey(key);
       await this.mDb.remove(key);
-      this.notifyStorageChange(database, table, key);
+      if (existed) {
+        this.notifyStorageChange(database, table, key);
+      }
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Remove: ${err.message}`);

--- a/src/web.ts
+++ b/src/web.ts
@@ -17,6 +17,7 @@ import type {
   capStoreJson,
   capDataStorageChanges,
   capStoreImportOptions,
+  capDataStorageChangeEvent,
 } from './definitions';
 import { Data } from './web-utils/Data';
 import { StorageDatabaseHelper } from './web-utils/StorageDatabaseHelper';
@@ -24,12 +25,30 @@ import { isJsonStore } from './web-utils/json-utils';
 
 export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements CapgoCapacitorDataStorageSqlitePlugin {
   private mDb!: StorageDatabaseHelper;
+  private currentDatabase = 'storage';
+  private currentTable = 'storage_store';
+
+  private notifyStorageChange(key: string, value?: string): void {
+    const event: capDataStorageChangeEvent = {
+      database: this.currentDatabase,
+      table: this.currentTable,
+      key,
+    };
+    if (value != null) {
+      event.value = value;
+    } else {
+      event.deleted = true;
+    }
+    this.notifyListeners(key, event);
+  }
 
   async openStore(options: capOpenStorageOptions): Promise<void> {
     const dbName = options.database ? `${options.database}IDB` : 'storageIDB';
     const tableName = options.table ? options.table : 'storage_store';
     try {
       this.mDb = new StorageDatabaseHelper(dbName, tableName);
+      this.currentDatabase = options.database ? options.database : 'storage';
+      this.currentTable = tableName;
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`OpenStore: ${err.message}`);
@@ -52,6 +71,7 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     if (this.mDb) {
       try {
         await this.mDb.setTable(tableName);
+        this.currentTable = tableName;
         return Promise.resolve();
       } catch (err: any) {
         return Promise.reject(`SetTable: ${err.message}`);
@@ -75,6 +95,7 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     data.value = value;
     try {
       await this.mDb.set(data);
+      this.notifyStorageChange(key, value);
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Set: ${err.message}`);
@@ -103,6 +124,7 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     }
     try {
       await this.mDb.remove(key);
+      this.notifyStorageChange(key);
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Remove: ${err.message}`);
@@ -110,7 +132,9 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
   }
   async clear(): Promise<void> {
     try {
+      const keys = await this.mDb.keys();
       await this.mDb.clear();
+      keys.forEach((key) => this.notifyStorageChange(key));
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Clear: ${err.message}`);
@@ -233,11 +257,13 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
         return Promise.reject('Must provide a valid JsonSQLite Object');
       }
       const vJsonObj: JsonStore = jsonObj;
+      this.currentDatabase = vJsonObj.database ? vJsonObj.database : 'storage';
       const dbName = vJsonObj.database ? `${vJsonObj.database}IDB` : 'storageIDB';
       for (const table of vJsonObj.tables) {
         const tableName = table.name ? table.name : 'storage_store';
         try {
           this.mDb = new StorageDatabaseHelper(dbName, tableName);
+          this.currentTable = tableName;
           // Open the database
           const bRet: boolean = this.mDb.openStore(dbName, tableName);
           if (bRet) {
@@ -245,6 +271,9 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
             if (table?.values) {
               const changes = await this.mDb.importJson(table.values);
               totalChanges += changes;
+              table.values.forEach((value) => {
+                this.notifyStorageChange(value.key, value.value);
+              });
             }
           } else {
             return Promise.reject(`Open store: ${dbName} : table: ${tableName} failed`);

--- a/src/web.ts
+++ b/src/web.ts
@@ -28,17 +28,9 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
   private currentDatabase = 'storage';
   private currentTable = 'storage_store';
 
-  private notifyStorageChange(key: string, value?: string): void {
-    const event: capDataStorageChangeEvent = {
-      database: this.currentDatabase,
-      table: this.currentTable,
-      key,
-    };
-    if (value != null) {
-      event.value = value;
-    } else {
-      event.deleted = true;
-    }
+  private notifyStorageChange(database: string, table: string, key: string, value?: string): void {
+    const event: capDataStorageChangeEvent =
+      value != null ? { database, table, key, value } : { database, table, key, deleted: true };
     this.notifyListeners(key, event);
   }
 
@@ -93,9 +85,11 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     const data: Data = new Data();
     data.name = key;
     data.value = value;
+    const database = this.currentDatabase;
+    const table = this.currentTable;
     try {
       await this.mDb.set(data);
-      this.notifyStorageChange(key, value);
+      this.notifyStorageChange(database, table, key, value);
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Set: ${err.message}`);
@@ -122,19 +116,23 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
     if (key == null || typeof key != 'string') {
       return Promise.reject('Remove: Must provide key as string');
     }
+    const database = this.currentDatabase;
+    const table = this.currentTable;
     try {
       await this.mDb.remove(key);
-      this.notifyStorageChange(key);
+      this.notifyStorageChange(database, table, key);
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Remove: ${err.message}`);
     }
   }
   async clear(): Promise<void> {
+    const database = this.currentDatabase;
+    const table = this.currentTable;
     try {
       const keys = await this.mDb.keys();
       await this.mDb.clear();
-      keys.forEach((key) => this.notifyStorageChange(key));
+      keys.forEach((key) => this.notifyStorageChange(database, table, key));
       return Promise.resolve();
     } catch (err: any) {
       return Promise.reject(`Clear: ${err.message}`);
@@ -257,7 +255,8 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
         return Promise.reject('Must provide a valid JsonSQLite Object');
       }
       const vJsonObj: JsonStore = jsonObj;
-      this.currentDatabase = vJsonObj.database ? vJsonObj.database : 'storage';
+      const database = vJsonObj.database ? vJsonObj.database : 'storage';
+      this.currentDatabase = database;
       const dbName = vJsonObj.database ? `${vJsonObj.database}IDB` : 'storageIDB';
       for (const table of vJsonObj.tables) {
         const tableName = table.name ? table.name : 'storage_store';
@@ -272,7 +271,7 @@ export class CapgoCapacitorDataStorageSqliteWeb extends WebPlugin implements Cap
               const changes = await this.mDb.importJson(table.values);
               totalChanges += changes;
               table.values.forEach((value) => {
-                this.notifyStorageChange(value.key, value.value);
+                this.notifyStorageChange(database, tableName, value.key, value.value);
               });
             }
           } else {


### PR DESCRIPTION
## What
- Add key-scoped change listeners to the data storage plugin.
- Add native iOS and Android listener APIs plus Capacitor JS `addListener(key, ...)` events.
- Document native and JS usage in README.

## Why
- Native app surfaces like CarPlay, Android Auto, widgets, and app extensions need to react to persisted storage changes without depending on an active WebView.

## How
- Added native weak listener registries on iOS and Android.
- Emit change events after successful `set`, `remove`, `clear`, current-table `deleteTable`, and `importFromJson` operations.
- Forward native events to JS listeners using the storage key as the listener event name.
- Added web listener parity for browser storage changes.

## Testing
- `bun ./node_modules/typescript/bin/tsc --noEmit`
- `bun ./node_modules/eslint/bin/eslint.js .`
- `bun ./node_modules/prettier/bin/prettier.cjs --plugin=prettier-plugin-java --check src/definitions.ts src/web.ts android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlite.java android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/CapgoCapacitorDataStorageSqlitePlugin.java android/src/main/java/com/jeep/plugin/capacitor/capgocapacitordatastoragesqlite/cdssUtils/StorageDatabaseHelper.java`
- `bun scripts/check-capacitor-plugin-wiring.mjs`
- `bun ./node_modules/swiftlint/bin.js lint` (only existing warnings remain)
- `xcodebuild -scheme CapgoCapacitorDataStorageSqlite -destination generic/platform=iOS`
- `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="$HOME/Library/Android/sdk" ANDROID_SDK_ROOT="$HOME/Library/Android/sdk" ./gradlew clean build test`
- Manual web build steps: docgen, TypeScript compile, Rollup API bundle generation.

## Not Tested
- Runtime CarPlay / Android Auto integration with a host app native subscriber.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added key-level change listeners: JavaScript can now subscribe to real-time storage change events for specific keys, receiving notifications when values are set, removed, or cleared across all platforms.

* **Chores**
  * Improved build script platform initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->